### PR TITLE
Addition of Adress features

### DIFF
--- a/src/main/java/com/krei/cmpackagecouriers/ServerConfig.java
+++ b/src/main/java/com/krei/cmpackagecouriers/ServerConfig.java
@@ -14,18 +14,26 @@ public class ServerConfig {
             .comment("enables targeting players with cardboard planes")
             .define("enablePlanePlayerLogistics", true);
 
+    private static final ModConfigSpec.BooleanValue SHOP_ADDRESS_REPLACEMENT = BUILDER
+        .comment("enables integration with Create's Shop system that rewrites @player addresses to the ordering player's nick)")
+        .define("enableShopAddressReplacement", true);
+
+
     static final ModConfigSpec SPEC = BUILDER.build();
 
     public static boolean planeLocationTargets;
     public static boolean planePlayerTargets;
+    public static boolean shopAddressReplacement;
 
     static void onLoad(final ModConfigEvent event) {
         planeLocationTargets = PLANE_LOCATION_TARGETS.get();
         planePlayerTargets = PLANE_PLAYER_TARGETS.get();
+        shopAddressReplacement = SHOP_ADDRESS_REPLACEMENT.get();
     }
 
     static void onReload(final ModConfigEvent event) {
         planeLocationTargets = PLANE_LOCATION_TARGETS.get();
         planePlayerTargets = PLANE_PLAYER_TARGETS.get();
+        shopAddressReplacement = SHOP_ADDRESS_REPLACEMENT.get();
     }
 }

--- a/src/main/java/com/krei/cmpackagecouriers/events/StockTickerIntegration.java
+++ b/src/main/java/com/krei/cmpackagecouriers/events/StockTickerIntegration.java
@@ -10,16 +10,15 @@ import net.neoforged.fml.common.EventBusSubscriber;
 import net.minecraft.core.BlockPos;
 
 import static com.krei.cmpackagecouriers.PackageCouriers.MODID;
+import com.krei.cmpackagecouriers.ServerConfig;
 
 import com.simibubi.create.content.logistics.stockTicker.StockTickerInteractionHandler;
 import com.simibubi.create.content.logistics.tableCloth.ShoppingListItem;
 import com.simibubi.create.content.processing.burner.BlazeBurnerBlock;
-import org.slf4j.Logger;
-import com.mojang.logging.LogUtils;
+
 // copied from DadudeGaming/Create.Mobile.packages.Unofficial under MIT License
 @EventBusSubscriber(modid = MODID)
 public class StockTickerIntegration {
-    private static final Logger LOGGER = LogUtils.getLogger();
 
     private static void rewriteAddressIfNeeded(Player player, ItemStack heldItem) {
         if (heldItem.getItem() instanceof ShoppingListItem) {
@@ -34,6 +33,7 @@ public class StockTickerIntegration {
 
     @SubscribeEvent(priority = net.neoforged.bus.api.EventPriority.HIGHEST)
     public static void onRightClickEntity(PlayerInteractEvent.EntityInteractSpecific event) {
+        if (!ServerConfig.shopAddressReplacement) return;
         if (event.getLevel().isClientSide()) {
             return;
         }
@@ -55,6 +55,7 @@ public class StockTickerIntegration {
 
     @SubscribeEvent(priority = net.neoforged.bus.api.EventPriority.HIGHEST)
     public static void onRightClickBlock(RightClickBlock event) {
+        if (!ServerConfig.shopAddressReplacement) return;
         if (event.getLevel().isClientSide()) {
             return;
         }

--- a/src/main/java/com/krei/cmpackagecouriers/events/StockTickerIntegration.java
+++ b/src/main/java/com/krei/cmpackagecouriers/events/StockTickerIntegration.java
@@ -1,0 +1,76 @@
+package com.krei.cmpackagecouriers.events;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.InteractionHand;
+import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent;
+import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent.RightClickBlock;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.minecraft.core.BlockPos;
+
+import static com.krei.cmpackagecouriers.PackageCouriers.MODID;
+
+import com.simibubi.create.content.logistics.stockTicker.StockTickerInteractionHandler;
+import com.simibubi.create.content.logistics.tableCloth.ShoppingListItem;
+import com.simibubi.create.content.processing.burner.BlazeBurnerBlock;
+import org.slf4j.Logger;
+import com.mojang.logging.LogUtils;
+// copied from DadudeGaming/Create.Mobile.packages.Unofficial under MIT License
+@EventBusSubscriber(modid = MODID)
+public class StockTickerIntegration {
+    private static final Logger LOGGER = LogUtils.getLogger();
+
+    private static void rewriteAddressIfNeeded(Player player, ItemStack heldItem) {
+        if (heldItem.getItem() instanceof ShoppingListItem) {
+            String currentAddress = ShoppingListItem.getAddress(heldItem);
+            if (currentAddress.toLowerCase().contains("@player")) {
+                String playerIdentifier = player.getDisplayName().getString();
+                String newAddress = currentAddress.replaceAll("(?i)@player", "@" + playerIdentifier);
+                ShoppingListItem.saveList(heldItem, ShoppingListItem.getList(heldItem), newAddress);
+            }
+        }
+    }
+
+    @SubscribeEvent(priority = net.neoforged.bus.api.EventPriority.HIGHEST)
+    public static void onRightClickEntity(PlayerInteractEvent.EntityInteractSpecific event) {
+        if (event.getLevel().isClientSide()) {
+            return;
+        }
+
+        Entity target = event.getTarget();
+        Player player = event.getEntity();
+        InteractionHand hand = event.getHand();
+        ItemStack heldItem = player.getItemInHand(hand);
+
+        if (player == null || target == null || player.isSpectator() || hand != InteractionHand.MAIN_HAND) {
+            return;
+        }
+
+        BlockPos stockTickerPos = StockTickerInteractionHandler.getStockTickerPosition(target);
+        if (stockTickerPos != null) {
+            rewriteAddressIfNeeded(player, heldItem);
+        }
+    }
+
+    @SubscribeEvent(priority = net.neoforged.bus.api.EventPriority.HIGHEST)
+    public static void onRightClickBlock(RightClickBlock event) {
+        if (event.getLevel().isClientSide()) {
+            return;
+        }
+
+        Player player = event.getEntity();
+        InteractionHand hand = event.getHand();
+        ItemStack heldItem = player.getItemInHand(hand);
+        BlockPos pos = event.getPos();
+
+        if (player == null || player.isSpectator() || hand != InteractionHand.MAIN_HAND) {
+            return;
+        }
+
+        // Check if the block is a Blaze Burner
+        if (event.getLevel().getBlockState(pos).getBlock() instanceof BlazeBurnerBlock) {
+            rewriteAddressIfNeeded(player, heldItem);
+        }
+    }
+}

--- a/src/main/java/com/krei/cmpackagecouriers/plane/CardboardPlaneItem.java
+++ b/src/main/java/com/krei/cmpackagecouriers/plane/CardboardPlaneItem.java
@@ -171,7 +171,13 @@ public class CardboardPlaneItem extends Item implements EjectorLaunchEffect {
 
     public static String getAddress(ItemStack plane) {
         if (plane.getItem() instanceof CardboardPlaneItem) {
-            return PackageItem.getAddress(getPackage(plane));
+            // added handling of @ in address to alow adress chaining and identifying player names
+            String address = PackageItem.getAddress(getPackage(plane));
+            int atIndex = address.indexOf('@');
+            if (atIndex != -1) {
+                address = address.substring(atIndex + 1);
+            }
+            return address;
         }
         return "";
     }


### PR DESCRIPTION
I added 2 handy adress features.
1) Planes can extract a players name as adress from longer adress strings. The player name needs to be lead by a @. This allows for adresses like: Plane-@agent772 (and therefore a sub routing in the logistic system)
2) when shoping with create table cloths they can have @player as adress. When a player then orders at a entity or blaze burner the @player gets replaced by the players name and therefore allows the sending to the shopping player. This is configurable via config (this was copied from [DadudeGaming](https://github.com/DadudeGaming)
[Create-Mobile-Packages-Unofficial](https://github.com/DadudeGaming/Create-Mobile-Packages-Unofficial))

Ponder scenes are still missing to explain the snipping via shears, the new @ address behavior and the table cloth rewrite.
I tried creating those but cant get it working -.- 
i gave up on the ponders