### PR TITLE
Update to Create 6.0.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ repositories {
     maven { url = 'https://maven.neoforged.net/#/releases/' }
     maven { url = "https://dl.zznty.ru/maven" } // Create Factory Abstractions, Create Factory Logistics
     maven { url = "https://maven.theillusivec4.top/" }
+    maven { url = "https://maven.squiddev.cc" } // CC: Tweaked
 }
 
 
@@ -112,6 +113,9 @@ dependencies {
     compileOnly "top.theillusivec4.curios:curios-neoforge:${curios_version}:api"
     runtimeOnly "top.theillusivec4.curios:curios-neoforge:${curios_version}"
 
+    compileOnly("cc.tweaked:cc-tweaked-${minecraft_version}-core-api:${cc_tweaked_version}")
+    compileOnly("cc.tweaked:cc-tweaked-${minecraft_version}-forge-api:${cc_tweaked_version}")
+    runtimeOnly("cc.tweaked:cc-tweaked-${minecraft_version}-forge:${cc_tweaked_version}")
 }
 
 var generateModMetadata = tasks.register("generateModMetadata", ProcessResources) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,24 +13,26 @@ parchment_mappings_version=2024.11.17
 # Environment Properties
 minecraft_version=1.21.1
 minecraft_version_range=[1.21.1, 1.22)
-neo_version=21.1.192
+neo_version=21.1.200
 neo_version_range=[21.1.0,)
 loader_version_range=[4,)
-create_version = 6.0.7-110
+create_version = 6.0.8-169
 create_version_range = [6.0.0,)
-ponder_version = 1.0.60
+ponder_version = 1.0.64
 flywheel_minecraft_version = 1.21.1
-flywheel_version = 1.0.4
-registrate_version = MC1.21-1.3.0+62
-create_factory_abstractions_version=1.4.6
+flywheel_version = 1.0.5
+registrate_version = MC1.21-1.3.0+67
+#not compatible with 6.0.8 yet
+create_factory_abstractions_version=1.4.8
 jei_version=19.21.0.247
 curios_version=9.5.1+1.21.1
+cc_tweaked_version = 1.116.1
 
 ## Mod Properties
 mod_id=cmpackagecouriers
 mod_name=Create More: Package Couriers
 mod_license=MIT License
-mod_version=1.5.0
+mod_version=1.5.1
 mod_group_id=com.krei.cmpackagecouriers
 mod_authors=Krei
 mod_description=Adds more ways to deliver packages in Create.

--- a/src/main/java/com/krei/cmpackagecouriers/stock_ticker/PortableStockTickerScreen.java
+++ b/src/main/java/com/krei/cmpackagecouriers/stock_ticker/PortableStockTickerScreen.java
@@ -12,7 +12,6 @@ import com.simibubi.create.content.logistics.stockTicker.PackageOrder;
 import com.simibubi.create.content.logistics.stockTicker.PackageOrderWithCrafts;
 import com.simibubi.create.content.trains.station.NoShadowFontWrapper;
 import com.simibubi.create.foundation.gui.AllGuiTextures;
-import com.simibubi.create.foundation.gui.ScreenWithStencils;
 import com.simibubi.create.foundation.gui.menu.AbstractSimiContainerScreen;
 import com.simibubi.create.foundation.gui.widget.ScrollInput;
 import com.simibubi.create.foundation.utility.CreateLang;
@@ -56,7 +55,7 @@ import javax.annotation.Nullable;
 import java.util.*;
 
 // Shamelessly copied from Create: Mobile Packages
-public class PortableStockTickerScreen extends AbstractSimiContainerScreen<PortableStockTickerMenu> implements ScreenWithStencils, OrderProvider, CategoriesProvider {
+public class PortableStockTickerScreen extends AbstractSimiContainerScreen<PortableStockTickerMenu> implements OrderProvider, CategoriesProvider {
 
     private static final AllGuiTextures NUMBERS = AllGuiTextures.NUMBERS;
     private static final AllGuiTextures HEADER = AllGuiTextures.STOCK_KEEPER_REQUEST_HEADER;
@@ -418,9 +417,8 @@ public class PortableStockTickerScreen extends AbstractSimiContainerScreen<Porta
         int itemWindowY = y + 17;
         int itemWindowY2 = y + windowHeight - 80;
 
-        UIRenderHelper.swapAndBlitColor(minecraft.getMainRenderTarget(), UIRenderHelper.framebuffer);
-        startStencil(pGuiGraphics, itemWindowX - 5, itemWindowY, itemWindowX2 - itemWindowX + 10,
-                     itemWindowY2 - itemWindowY);
+        // UIRenderHelper.swapAndBlitColor(minecraft.getMainRenderTarget(), UIRenderHelper.framebuffer);
+		pGuiGraphics.enableScissor(itemWindowX - 5, itemWindowY, itemWindowX2 + 10, itemWindowY2);
 
         ms.pushPose();
         ms.translate(0, -currentScroll * rowHeight, 0);
@@ -508,7 +506,7 @@ public class PortableStockTickerScreen extends AbstractSimiContainerScreen<Porta
         }
 
         ms.popPose();
-        endStencil();
+        pGuiGraphics.disableScissor();
 
         // Scroll bar
         int windowH = windowHeight - 92;
@@ -556,7 +554,7 @@ public class PortableStockTickerScreen extends AbstractSimiContainerScreen<Porta
             ms.popPose();
         }
 
-        UIRenderHelper.swapAndBlitColor(UIRenderHelper.framebuffer, minecraft.getMainRenderTarget());
+        // UIRenderHelper.swapAndBlitColor(UIRenderHelper.framebuffer, minecraft.getMainRenderTarget());
     }
 
     private int getMaxScroll() {


### PR DESCRIPTION
Update dependencies and fix the PortableStockTickerScreen to work on Create 6.0.8.
Note that [Create Factory Logistics](https://github.com/zznty/CreateFactoryLogistics/) is not yet available for 6.0.8, but this mod will run without it.

Solves #26 
Bumps mod to 1.5.1.