### PR TITLE
Player name accessed with scoreboardName

### DIFF
--- a/src/main/java/com/kreidev/cmpackagecouriers/StockTickerIntegration.java
+++ b/src/main/java/com/kreidev/cmpackagecouriers/StockTickerIntegration.java
@@ -24,7 +24,7 @@ public class StockTickerIntegration {
         if (heldItem.getItem() instanceof ShoppingListItem) {
             String currentAddress = ShoppingListItem.getAddress(heldItem);
             if (currentAddress.toLowerCase().contains("<>")) {
-                String playerIdentifier = player.getDisplayName().getString();
+                String playerIdentifier = player.getScoreboardName();
                 String newAddress = currentAddress.replaceAll("<>", "<" + playerIdentifier + ">");
                 ShoppingListItem.saveList(heldItem, ShoppingListItem.getList(heldItem), newAddress);
             }


### PR DESCRIPTION
You should replace your `player.getDisplayName().toString()` with `player.getScoreboardName()` ;)

The reason is getScoreboardName returns the nickname, while `getDisplayName()` returns the display name component after applying team prefixes/suffixes

I found this issue on a server where we had several ranks. Getting the display name returns `[MyRank] myNickName` instead of my nickname, making the package impossible to be delivered.